### PR TITLE
English in input schema

### DIFF
--- a/INPUT_SCHEMA.json
+++ b/INPUT_SCHEMA.json
@@ -23,7 +23,7 @@
             "nullable": true
         },
         "postsFromDate": {
-            "title": "Videos from date",
+            "title": "Videos since date",
             "type": "string",
             "editor": "textfield",
             "description": "How far back in history to go e.g <br />30 minutes ago <br />1 week ago <br />5 months ago <br />4 years ago, etc.<br />for 'No limits' empty the field",


### PR DESCRIPTION
When I have "Videos from date" and then 5 years ago, it means and feels like 5 years old videos, not videos for 5 years, i.e. videos SINCE 5 years ago.