### PR TITLE
Add comment count

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -47,5 +47,6 @@ exports.SELECTORS = {
         subscribersXp: "//*[@id='owner-sub-count']",
         descriptionXp: '//ytd-expander/div/div/yt-formatted-string',
         durationSlctr: '#movie_player span.ytp-time-duration',
+        commentsSlctr: '.count-text',
     },
 };


### PR DESCRIPTION
Included comment count to the output. Needed to scroll twice to get the comments on the platform (scrolling once was enough locally). Let's test a bit further.