### PR TITLE
add parsing for alternative selectors

### DIFF
--- a/src/crawler_utils.js
+++ b/src/crawler_utils.js
@@ -285,17 +285,32 @@ const getBasicInformation = async (basicInfoParams) => {
                         const videoDetails = await video.$eval(videoTitle, (el) => el.ariaLabel) || '';
 
                         const videoDetailsArray = videoDetails.replace(title, ``).replace(`by ${channelName}`, ``).split(' ').filter((item) => item);
-                        const simplifiedDate = videoDetailsArray.slice(0, 3).join(' ');
+                        let simplifiedDate = videoDetailsArray.slice(0, 3).join(' ');
                         const viewCount = +videoDetailsArray[videoDetailsArray.length - 2].replace(/\D/g, '');
-                        const durationRaw = videoDetailsArray.slice(3, videoDetailsArray.length - 2).join(' ');
+                        let durationRaw = videoDetailsArray.slice(3, videoDetailsArray.length - 2).join(' ');
 
                         let duration;
+                        let isError = false;
 
                         try {
                             duration = await video.$eval(`span[aria-label="${durationRaw}"]`, (el) => el.innerText);
                         } catch (e) {
                             console.log(`Couldn't parse duration, sending the raw duration`);
-                            duration = durationRaw;
+                            isError = true;
+                        }
+
+
+                        // second attempt to get the duration from the alternative version
+                        if (isError) {
+                            try {
+                                console.log(`Trying to parse alternative duration`);
+                                durationRaw = videoDetailsArray.slice(2, videoDetailsArray.length - 2).join(' ');
+                                simplifiedDate = videoDetailsArray.slice(2, 5).join(' ');
+                                duration = await video.$eval(`span[aria-label="${durationRaw}"]`, (el) => el.innerText);
+                            } catch (e) {
+                                console.log(`Couldn't parse duration, sending the raw duration`);
+                                duration = durationRaw;
+                            }
                         }
 
                         videoAmount++;


### PR DESCRIPTION
We are getting different results for local run and platform runs. Added a simple functionality to parse both cases. (It can be A/B testing as well)